### PR TITLE
Shorten text for API menu link.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
     <a href="/faq.html">FAQ</a>
     <a href="/es6.html">ES6</a>
     <a href="/blogg.html">BLOGG</a>
-    <a href="https://iojs.org/api/">API-dokumentasjon</a>
+    <a href="https://iojs.org/api/">API</a>
   </div>
 </header>
 


### PR DESCRIPTION
Som diskutert i #22. Quick fix med å bruke ordet API i stedet for ordet API-dokumentasjon.

Attached før og etter på 320px bred mobil

![screen shot 2015-02-09 at 14 03 04](https://cloud.githubusercontent.com/assets/865153/6106740/760d3178-b064-11e4-8528-a6638e91d627.png)
![screen shot 2015-02-09 at 12 05 22](https://cloud.githubusercontent.com/assets/865153/6106741/760e905e-b064-11e4-9916-0ed4ec2fda85.png)
