### PR TITLE
switches 1.4.2, 4.1.0.21 to variables

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -7,7 +7,7 @@ spesifikasjonen](http://www.ecma-international.org/publications/standards/Ecma-2
 er tilgjengelig for io.js utviklere innen rimelig tid. I tillegg vil
 sikkerhets- og ytelesesforbedringer komme raskt.
 
-Versjon 1.4.2 av io.js kommer med V8 versjon 4.1.0.21, denne inkluderer
+Versjon {{project.current_version}} av io.js kommer med V8 versjon {{project.current_v8}}, denne inkluderer
 ES6-funksjoner godt forbi versjon 3.28.73 som vil bli levert med Node.js™
 0.12.x.
 
@@ -128,4 +128,3 @@ du skrive følgende i terminalen:
 ```sh
 iojs -p process.versions.v8
 ```
-

--- a/index.md
+++ b/index.md
@@ -5,16 +5,16 @@ Bringer [ES6](es6.html) til Node-fellesskapet!
 [io.js](https://iojs.org)  er en [npm](https://www.npmjs.org)-kompatibel
 platform opprinnelig basert på [node.js](https://nodejs.org/)&#8482;.
 
-[![io.js](/images/1.0.0.png)](https://iojs.org/dist/v1.4.2/)
+[![io.js](/images/1.0.0.png)](https://iojs.org/dist/v{{project.current_version}}/)
 
-[Versjon 1.4.2](https://iojs.org/dist/v1.4.2/)
+[Versjon {{project.current_version}}](https://iojs.org/dist/v{{project.current_version}}/)
 
 Last ned til
-[Linux](https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz),
-[Win32](https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi),
-[Win64](https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi),
-[Mac](https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg), eller
-[andre](https://iojs.org/dist/v1.4.2/).
+[Linux](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-linux-x64.tar.xz),
+[Win32](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-x86.msi),
+[Win64](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-x64.msi),
+[Mac](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}.pkg), eller
+[andre](https://iojs.org/dist/v{{project.current_version}}/).
 
 [Se endringer (engelsk)](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
 


### PR DESCRIPTION
Not sure if you want this variation (if it stomps over the version output of your current build processes) but this is what my PR is using based off the subtree experiments. I can roll that part back for now if easier and you can ignore this :)
